### PR TITLE
feat(consume new sector builder interface)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-filecoin-proofs = { git = "https://github.com/filecoin-project/rust-proofs", branch = "safe-filproofs" }
-sector-base = { git = "https://github.com/filecoin-project/rust-proofs", branch = "safe-filproofs" }
+filecoin-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-proofs" }
+sector-builder = { rev = "f435451187745b741e6026317c309706439e2839", git = "https://github.com/filecoin-project/rust-fil-sector-builder"}
 
 clap = "2.33.0"
 failure = "0.1.5"
@@ -29,7 +29,7 @@ fil-sapling-crypto = {version = "0.1.0", optional = true}
 memmap = {version = "0.7.0", optional = true}
 serde_json = { version = "1.0.39", optional = true }
 tempfile = { version = "3.0.8", optional = true }
-storage-proofs = { git = "https://github.com/filecoin-project/rust-proofs", branch = "safe-filproofs", optional = true }
+storage-proofs = { rev = "07de4ef9eac5400335229678c0cc01ab8d967273", git = "https://github.com/filecoin-project/rust-proofs", optional = true }
 prometheus = { version = "0.6.0", optional = true }
 
 [features]

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,3 @@
-use filecoin_proofs::api::sector_builder::metadata::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -38,7 +37,7 @@ pub enum Request {
     // -- Piece
     PieceAdd {
         key: String,
-        amount: Option<u64>,
+        amount: u64,
         path: String,
     },
     PieceRead(String),
@@ -56,12 +55,12 @@ pub enum Response {
     // -- Seal
     SealVerify(bool),
     SealAllStaged,
-    SealStatus(SealStatus),
+    SealStatus(sector_builder::SealStatus),
 
     // -- Sector
     SectorSize(u64),
-    SectorListSealed(Vec<SealedSectorMetadata>),
-    SectorListStaged(Vec<StagedSectorMetadata>),
+    SectorListSealed(Vec<sector_builder::SealedSectorMetadata>),
+    SectorListStaged(Vec<sector_builder::StagedSectorMetadata>),
 
     // -- Piece
     PieceAdd(u64),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use clap::{App, AppSettings, Arg, SubCommand};
 
 pub fn get_matches() -> clap::ArgMatches<'static> {
-    let mut app = App::new("Filecoin Base")
+    let app = App::new("Filecoin Base")
         .version("1.0")
         .about("Manage all your sectors and proofs")
         .setting(AppSettings::ArgRequiredElseHelp)

--- a/src/cbor_codec.rs
+++ b/src/cbor_codec.rs
@@ -1,11 +1,11 @@
 // based on https://github.com/vorner/tokio-serde-cbor
 
-use failure::Error;
 use std::default::Default;
 use std::io::{Read, Result as IoResult, Write};
 use std::marker::PhantomData;
 
 use bytes::BytesMut;
+use failure::Error;
 use futures_codec::{Decoder as IoDecoder, Encoder as IoEncoder};
 use serde::{Deserialize, Serialize};
 use serde_cbor::de::{Deserializer, IoRead};
@@ -93,8 +93,6 @@ impl<'de, Item: Deserialize<'de>> IoDecoder for Decoder<Item> {
 /// called „magic“). This specifies if it should be present when encoding.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum SdMode {
-    /// Places the tag in front of each encoded frame.
-    Always,
     /// Places the tag in front of the first encoded frame.
     Once,
     /// Doesn't place the tag at all.
@@ -204,17 +202,6 @@ impl<'de, Dec: Deserialize<'de>, Enc: Serialize> Codec<Dec, Enc> {
         Self {
             dec: self.dec,
             enc: Encoder { sd, ..self.enc },
-        }
-    }
-    /// Turns the internal encoder into one with configured packed encoding.
-    ///
-    /// If `packed` is true, it omits the field names from the encoded data. That makes it smaller,
-    /// but it also means the decoding end must know the exact order of fields and it can't be
-    /// something like python, which would want to get a dictionary out of it.
-    pub fn packed(self, packed: bool) -> Self {
-        Self {
-            dec: self.dec,
-            enc: Encoder { packed, ..self.enc },
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -150,7 +150,7 @@ pub async fn sector_list_staged() -> Result<(), Error> {
 
 pub async fn piece_add<S1: AsRef<str>, S2: AsRef<str>>(
     key: S1,
-    amount: Option<u64>,
+    amount: u64,
     path: S2,
 ) -> Result<(), Error> {
     let res = send(Request::PieceAdd {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -11,7 +11,7 @@ macro_rules! hex_vec_arr {
         $matches
             .values_of($field)
             .expect("missing required field")
-            .map(|v| <[u8; $size] as hex::FromHex>::from_hex(v))
+            .map(<[u8; $size] as hex::FromHex>::from_hex)
             .collect::<Result<Vec<_>, _>>()
     }};
 }
@@ -21,7 +21,7 @@ macro_rules! hex_vec_vec {
         $matches
             .values_of($field)
             .expect("missing required field")
-            .map(|v| <Vec<u8> as hex::FromHex>::from_hex(v))
+            .map(<Vec<u8> as hex::FromHex>::from_hex)
             .collect::<Result<Vec<_>, _>>()
     }};
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 #![feature(async_await)]
 
+#[macro_use]
+extern crate failure;
+extern crate filecoin_proofs;
 #[cfg(feature = "benchy")]
 #[macro_use]
 extern crate prometheus;
+extern crate sector_builder;
 
 use clap::{value_t, values_t};
 use failure::bail;
@@ -112,7 +116,8 @@ async fn main() -> Result<(), failure::Error> {
                 let key = m.value_of("KEY").unwrap();
                 let amount = m
                     .value_of("amount")
-                    .map(|s| s.parse().expect("invalid size"));
+                    .map(|s| s.parse().expect("invalid size"))
+                    .unwrap();
                 let path = m.value_of("PATH").unwrap();
 
                 client::piece_add(key, amount, path).await
@@ -124,7 +129,7 @@ async fn main() -> Result<(), failure::Error> {
             }
             _ => bail!("Unknown subcommand"),
         },
-        ("benchy", Some(m)) => {
+        ("benchy", Some(_)) => {
             #[cfg(not(feature = "benchy"))]
             bail!("Please compile with the benchy feature flag to enable benchmarking");
             #[cfg(feature = "benchy")]


### PR DESCRIPTION
## Why is this PR needed?

The `rust-fil-proofs` crate has been decomposed into a bunch of other crates. This crate needs updating to consume the new interface.

## What's in this PR?

- Tidy up code such that it passes `clippy`.
- Update code to consume new `rust-fil-sector-builder` crate (in addition to `rust-fil-proofs`).